### PR TITLE
[SDTEST-1281] fixed public api. better multithreading for parser

### DIFF
--- a/CodeCoverage.xcodeproj/project.pbxproj
+++ b/CodeCoverage.xcodeproj/project.pbxproj
@@ -37,6 +37,10 @@
 		A7C84DF92CF71C930002115A /* CodeCoverage.hpp in Headers */ = {isa = PBXBuildFile; fileRef = A7C84DF52CF71C930002115A /* CodeCoverage.hpp */; };
 		A7C84DFA2CF71C930002115A /* ResetCounters.hpp in Headers */ = {isa = PBXBuildFile; fileRef = A7C84DF62CF71C930002115A /* ResetCounters.hpp */; };
 		A7D7E64B2CFDD2EA00B49C35 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7D7E64A2CFDD2EA00B49C35 /* Constants.swift */; };
+		A7D7E6532D08E02A00B49C35 /* BinaryCoverageReaderRef.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7D7E6512D08E02A00B49C35 /* BinaryCoverageReaderRef.cpp */; };
+		A7D7E6542D08E02A00B49C35 /* BinaryCoverageReaderRef.hpp in Headers */ = {isa = PBXBuildFile; fileRef = A7D7E6522D08E02A00B49C35 /* BinaryCoverageReaderRef.hpp */; };
+		A7D7E6572D08E25800B49C35 /* BinaryCoverageReaderRef.hpp in Headers */ = {isa = PBXBuildFile; fileRef = A7D7E6552D08E25800B49C35 /* BinaryCoverageReaderRef.hpp */; };
+		A7D7E6582D08E25800B49C35 /* BinaryCoverageReaderRef.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7D7E6562D08E25800B49C35 /* BinaryCoverageReaderRef.cpp */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -134,6 +138,10 @@
 		A7D7E64A2CFDD2EA00B49C35 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		A7D7E64C2D03CDC600B49C35 /* Makefile.llvm */ = {isa = PBXFileReference; lastKnownFileType = text; path = Makefile.llvm; sourceTree = "<group>"; };
 		A7D7E64D2D03CDC700B49C35 /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
+		A7D7E6512D08E02A00B49C35 /* BinaryCoverageReaderRef.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = BinaryCoverageReaderRef.cpp; sourceTree = "<group>"; };
+		A7D7E6522D08E02A00B49C35 /* BinaryCoverageReaderRef.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = BinaryCoverageReaderRef.hpp; sourceTree = "<group>"; };
+		A7D7E6552D08E25800B49C35 /* BinaryCoverageReaderRef.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = BinaryCoverageReaderRef.hpp; sourceTree = "<group>"; };
+		A7D7E6562D08E25800B49C35 /* BinaryCoverageReaderRef.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BinaryCoverageReaderRef.cpp; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -279,6 +287,8 @@
 			children = (
 				A712C1C12CEFEF5900B4282F /* Coverage.h */,
 				A712C1CC2CEFF1A700B4282F /* Coverage.cpp */,
+				A7D7E6522D08E02A00B49C35 /* BinaryCoverageReaderRef.hpp */,
+				A7D7E6512D08E02A00B49C35 /* BinaryCoverageReaderRef.cpp */,
 				A71756B02CF7196400240492 /* CodeCoverage.hpp */,
 				A71756AF2CF7196400240492 /* CodeCoverage.cpp */,
 				A71756972CF4EAE600240492 /* ResetCounters.hpp */,
@@ -290,6 +300,8 @@
 		A712C1E12CF0A37B00B4282F /* CCoverageLLVM17 */ = {
 			isa = PBXGroup;
 			children = (
+				A7D7E6552D08E25800B49C35 /* BinaryCoverageReaderRef.hpp */,
+				A7D7E6562D08E25800B49C35 /* BinaryCoverageReaderRef.cpp */,
 				A712C1E22CF0A37B00B4282F /* Coverage.h */,
 				A712C1EF2CF0A7D600B4282F /* Coverage.cpp */,
 				A7C84DF52CF71C930002115A /* CodeCoverage.hpp */,
@@ -334,6 +346,7 @@
 			files = (
 				A71756B22CF7196400240492 /* CodeCoverage.hpp in Headers */,
 				A712C1C22CEFEF5900B4282F /* Coverage.h in Headers */,
+				A7D7E6542D08E02A00B49C35 /* BinaryCoverageReaderRef.hpp in Headers */,
 				A71756992CF4EAE600240492 /* ResetCounters.hpp in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -344,6 +357,7 @@
 			files = (
 				A712C1E32CF0A37B00B4282F /* Coverage.h in Headers */,
 				A7C84DFA2CF71C930002115A /* ResetCounters.hpp in Headers */,
+				A7D7E6572D08E25800B49C35 /* BinaryCoverageReaderRef.hpp in Headers */,
 				A7C84DF92CF71C930002115A /* CodeCoverage.hpp in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -570,6 +584,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A71756982CF4EAE600240492 /* ResetCounters.cpp in Sources */,
+				A7D7E6532D08E02A00B49C35 /* BinaryCoverageReaderRef.cpp in Sources */,
 				A712C1CD2CEFF1A700B4282F /* Coverage.cpp in Sources */,
 				A71756B12CF7196400240492 /* CodeCoverage.cpp in Sources */,
 			);
@@ -580,6 +595,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A7C84DF72CF71C930002115A /* ResetCounters.cpp in Sources */,
+				A7D7E6582D08E25800B49C35 /* BinaryCoverageReaderRef.cpp in Sources */,
 				A712C1F02CF0A7D600B4282F /* Coverage.cpp in Sources */,
 				A7C84DF82CF71C930002115A /* CodeCoverage.cpp in Sources */,
 			);

--- a/Sources/CCoverageLLVM15/BinaryCoverageReaderRef.cpp
+++ b/Sources/CCoverageLLVM15/BinaryCoverageReaderRef.cpp
@@ -1,0 +1,40 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2024-Present Datadog, Inc.
+ */
+
+#include "BinaryCoverageReaderRef.hpp"
+
+using namespace llvm15;
+using namespace llvm;
+using namespace coverage;
+
+BinaryCoverageReaderRef::BinaryCoverageReaderRef(BinaryCoverageReader *Reader):
+    Filenames(Reader->getFilenamesRef()),
+    MappingRecords(Reader->getMappingRecordsRef()) {;}
+
+// Copied from BinaryCoverageReader::readNextRecord
+Error BinaryCoverageReaderRef::readNextRecord(CoverageMappingRecord &Record) {
+    if (CurrentRecord >= MappingRecords.size())
+        return make_error<CoverageMapError>(coveragemap_error::eof);
+
+    FunctionsFilenames.clear();
+    Expressions.clear();
+    MappingRegions.clear();
+    auto &R = MappingRecords[CurrentRecord];
+    auto F = Filenames.slice(R.FilenamesBegin, R.FilenamesSize);
+    RawCoverageMappingReader Reader(R.CoverageMapping, F, FunctionsFilenames,
+                                    Expressions, MappingRegions);
+    if (auto Err = Reader.read())
+        return Err;
+
+    Record.FunctionName = R.FunctionName;
+    Record.FunctionHash = R.FunctionHash;
+    Record.Filenames = FunctionsFilenames;
+    Record.Expressions = Expressions;
+    Record.MappingRegions = MappingRegions;
+
+    ++CurrentRecord;
+    return Error::success();
+}

--- a/Sources/CCoverageLLVM15/BinaryCoverageReaderRef.hpp
+++ b/Sources/CCoverageLLVM15/BinaryCoverageReaderRef.hpp
@@ -1,0 +1,25 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2024-Present Datadog, Inc.
+ */
+
+#pragma once
+#include <llvm15/ProfileData/Coverage/CoverageMappingReader.h>
+
+namespace llvm15 {
+
+class BinaryCoverageReaderRef: public llvm::coverage::CoverageMappingReader {
+private:
+    size_t CurrentRecord = 0;
+    llvm::ArrayRef<std::string> Filenames;
+    llvm::ArrayRef<llvm::coverage::BinaryCoverageReader::ProfileMappingRecord> MappingRecords;
+    std::vector<llvm::StringRef> FunctionsFilenames;
+    std::vector<llvm::coverage::CounterExpression> Expressions;
+    std::vector<llvm::coverage::CounterMappingRegion> MappingRegions;
+public:
+    BinaryCoverageReaderRef(llvm::coverage::BinaryCoverageReader *Reader);
+    llvm::Error readNextRecord(llvm::coverage::CoverageMappingRecord &Record) override;
+};
+
+}

--- a/Sources/CCoverageLLVM15/CodeCoverage.hpp
+++ b/Sources/CCoverageLLVM15/CodeCoverage.hpp
@@ -9,7 +9,6 @@
 #include <llvm15/ProfileData/Coverage/CoverageMapping.h>
 #include <llvm15/ProfileData/Coverage/CoverageMappingReader.h>
 #include <llvm15/Support/MemoryBuffer.h>
-#include <mutex>
 
 namespace llvm15 {
 
@@ -20,8 +19,7 @@ public:
     llvm::Expected<CCoverageFiles> coverage(llvm::StringRef ProfrawPath);
 private:
     CodeCoverage() {};
-    std::mutex MappingReadersLock;
-    std::vector<std::unique_ptr<llvm::coverage::CoverageMappingReader>> MappingReaders;
+    std::vector<std::unique_ptr<llvm::coverage::BinaryCoverageReader>> MappingReaders;
     llvm::Expected<std::unique_ptr<llvm::MemoryBuffer>> readProfile(llvm::StringRef ProfrawPath);
     CCoverageFile processFile(llvm::StringRef Name, llvm::coverage::CoverageMapping &Coverage);
 };

--- a/Sources/CCoverageLLVM17/BinaryCoverageReaderRef.cpp
+++ b/Sources/CCoverageLLVM17/BinaryCoverageReaderRef.cpp
@@ -1,0 +1,40 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2024-Present Datadog, Inc.
+ */
+
+#include "BinaryCoverageReaderRef.hpp"
+
+using namespace llvm17;
+using namespace llvm;
+using namespace coverage;
+
+BinaryCoverageReaderRef::BinaryCoverageReaderRef(BinaryCoverageReader *Reader):
+    Filenames(Reader->getFilenamesRef()),
+    MappingRecords(Reader->getMappingRecordsRef()) {;}
+
+// Copied from BinaryCoverageReader::readNextRecord
+Error BinaryCoverageReaderRef::readNextRecord(CoverageMappingRecord &Record) {
+    if (CurrentRecord >= MappingRecords.size())
+        return make_error<CoverageMapError>(coveragemap_error::eof);
+
+    FunctionsFilenames.clear();
+    Expressions.clear();
+    MappingRegions.clear();
+    auto &R = MappingRecords[CurrentRecord];
+    auto F = Filenames.slice(R.FilenamesBegin, R.FilenamesSize);
+    RawCoverageMappingReader Reader(R.CoverageMapping, F, FunctionsFilenames,
+                                    Expressions, MappingRegions);
+    if (auto Err = Reader.read())
+        return Err;
+
+    Record.FunctionName = R.FunctionName;
+    Record.FunctionHash = R.FunctionHash;
+    Record.Filenames = FunctionsFilenames;
+    Record.Expressions = Expressions;
+    Record.MappingRegions = MappingRegions;
+
+    ++CurrentRecord;
+    return Error::success();
+}

--- a/Sources/CCoverageLLVM17/BinaryCoverageReaderRef.hpp
+++ b/Sources/CCoverageLLVM17/BinaryCoverageReaderRef.hpp
@@ -1,0 +1,25 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2024-Present Datadog, Inc.
+ */
+
+#pragma once
+#include <llvm17/ProfileData/Coverage/CoverageMappingReader.h>
+
+namespace llvm17 {
+
+class BinaryCoverageReaderRef: public llvm::coverage::CoverageMappingReader {
+private:
+    size_t CurrentRecord = 0;
+    llvm::ArrayRef<std::string> Filenames;
+    llvm::ArrayRef<llvm::coverage::BinaryCoverageReader::ProfileMappingRecord> MappingRecords;
+    std::vector<llvm::StringRef> FunctionsFilenames;
+    std::vector<llvm::coverage::CounterExpression> Expressions;
+    std::vector<llvm::coverage::CounterMappingRegion> MappingRegions;
+public:
+    BinaryCoverageReaderRef(llvm::coverage::BinaryCoverageReader *Reader);
+    llvm::Error readNextRecord(llvm::coverage::CoverageMappingRecord &Record) override;
+};
+
+}

--- a/Sources/CCoverageLLVM17/CodeCoverage.cpp
+++ b/Sources/CCoverageLLVM17/CodeCoverage.cpp
@@ -5,7 +5,7 @@
  */
 
 #include "CodeCoverage.hpp"
-#include <sstream>
+#include "BinaryCoverageReaderRef.hpp"
 
 #include "llvm17/ADT/ArrayRef.h"
 #include "llvm17/ProfileData/InstrProfReader.h"
@@ -169,20 +169,24 @@ Expected<CCoverageFiles> CodeCoverage::coverage(StringRef ProfrawPath) {
     }
     auto ProfileReader = std::move(ProfileReaderOrErr.get());
     
-    // BinaryCoverageReader isn't thread safe. We have to lock.
-    MappingReadersLock.lock();
-    // We are using method from our patch so we can reuse readers.
-    // dynamic_cast can't be used because of lack of RTTI.
-    // it's safe because LLVM version is locked
-    // and we know that BinaryCoverageReader inherited directly from the base class.
+    // We are using methods from our patch so we can reuse readers.
+    // We will create Ref classes for the real readers so we can iterate
+    // in the different threads at the same time.
+    std::vector<std::unique_ptr<CoverageMappingReader>> Readers;
+    Readers.reserve(MappingReaders.size());
+    
     for (auto &Reader: MappingReaders) {
-        reinterpret_cast<BinaryCoverageReader*>(Reader.get())->reset();
+        Readers.push_back(
+            std::unique_ptr<CoverageMappingReader>(
+                new BinaryCoverageReaderRef(Reader.get())
+            )
+        );
     }
+    
     // create coverage mapping from resetted readers and profile
-    auto CoverageOrErr = CoverageMapping::load(ArrayRef(MappingReaders), *ProfileReader);
-    //unlock
-    MappingReadersLock.unlock();
-    // handle error
+    auto CoverageOrErr = CoverageMapping::load(ArrayRef(Readers), *ProfileReader);
+    
+    // handle errors
     if (Error E = CoverageOrErr.takeError()) {
         return std::move(E);
     }

--- a/Sources/CCoverageLLVM17/CodeCoverage.hpp
+++ b/Sources/CCoverageLLVM17/CodeCoverage.hpp
@@ -9,7 +9,6 @@
 #include <llvm17/ProfileData/Coverage/CoverageMapping.h>
 #include <llvm17/ProfileData/Coverage/CoverageMappingReader.h>
 #include <llvm17/Support/MemoryBuffer.h>
-#include <mutex>
 
 namespace llvm17 {
 
@@ -20,8 +19,7 @@ public:
     llvm::Expected<CCoverageFiles> coverage(llvm::StringRef ProfrawPath);
 private:
     CodeCoverage() {};
-    std::mutex MappingReadersLock;
-    std::vector<std::unique_ptr<llvm::coverage::CoverageMappingReader>> MappingReaders;
+    std::vector<std::unique_ptr<llvm::coverage::BinaryCoverageReader>> MappingReaders;
     llvm::Expected<std::unique_ptr<llvm::MemoryBuffer>> readProfile(llvm::StringRef ProfrawPath);
     CCoverageFile processFile(llvm::StringRef Name, llvm::coverage::CoverageMapping &Coverage);
 };

--- a/Sources/CodeCoverage/CoveredBinary.swift
+++ b/Sources/CodeCoverage/CoveredBinary.swift
@@ -9,8 +9,8 @@ import MachO
 @_implementationOnly import CCoverageLLVM
 
 public struct CoveredBinary {
-    let name: String
-    let path: String
+    public let name: String
+    public let path: String
     // __llvm_profile_initialize
     let profileInitializeFileFunc: @convention(c) () -> Void
     // __llvm_profile_set_page_size

--- a/llvm/patches/15.0.0/reader-getters-patch.diff
+++ b/llvm/patches/15.0.0/reader-getters-patch.diff
@@ -1,12 +1,13 @@
 --- a/llvm/include/llvm/ProfileData/Coverage/CoverageMappingReader.h
 +++ b/llvm/include/llvm/ProfileData/Coverage/CoverageMappingReader.h
-@@ -217,6 +217,8 @@ public:
+@@ -216,6 +216,10 @@ public:
                                   StringRef CompilationDir = "");
  
    Error readNextRecord(CoverageMappingRecord &Record) override;
 +
-+  void reset() { CurrentRecord = 0; };
++  ArrayRef<std::string> getFilenamesRef() { return ArrayRef<std::string>(Filenames); };
++
++  ArrayRef<ProfileMappingRecord> getMappingRecordsRef() { return ArrayRef<ProfileMappingRecord>(MappingRecords); };
  };
  
  /// Reader for the raw coverage filenames.
- 

--- a/llvm/patches/17.0.6/reader-getters-patch.diff
+++ b/llvm/patches/17.0.6/reader-getters-patch.diff
@@ -1,12 +1,13 @@
 --- a/llvm/include/llvm/ProfileData/Coverage/CoverageMappingReader.h
 +++ b/llvm/include/llvm/ProfileData/Coverage/CoverageMappingReader.h
-@@ -216,6 +216,8 @@ public:
+@@ -217,6 +217,10 @@ public:
                                   StringRef CompilationDir = "");
  
    Error readNextRecord(CoverageMappingRecord &Record) override;
 +
-+  void reset() { CurrentRecord = 0; };
++  ArrayRef<std::string> getFilenamesRef() { return ArrayRef<std::string>(Filenames); };
++
++  ArrayRef<ProfileMappingRecord> getMappingRecordsRef() { return ArrayRef<ProfileMappingRecord>(MappingRecords); };
  };
  
  /// Reader for the raw coverage filenames.
- 


### PR DESCRIPTION
### What and why?

* Forgot to make couple of properties public.
* Needed more helpers methods in the main SDK
* Multithreaded performance could be better

### How?

* Added helper methods
* Made properties public
* Added reader Ref class in C++ part which allows us to use reader in multiple threads

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
