### PR TITLE
[chore] draft release creates broken links till published

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,5 +135,5 @@ github_release: build_release
 	@rm -f build/symbols/CodeCoverageParser.symbols.zip
 	@mv build/symbols/CodeCoverageParser.zip build/symbols/CodeCoverageParser.symbols.zip
 	# make github release
-	@gh release create $(version) --draft --verify-tag --generate-notes \
+	@gh release create $(version) --prerelease --verify-tag --generate-notes \
 		build/xcframework/CodeCoverageParser.zip build/symbols/CodeCoverageParser.symbols.zip


### PR DESCRIPTION
### What and why?

Draft release will have file links broken till it released. SPM will see tag already and it will lead to broken CI builds for customers. So it's better to do pre-release instead of draft and then edit it

### How?

Fixed release type in the script

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
