### PR TITLE
Attempt to fix FileSystem related crashes on multi-threaded parsing

### DIFF
--- a/Sources/CCodeCoverageParserLLVM17/CodeCoverage.cpp
+++ b/Sources/CCodeCoverageParserLLVM17/CodeCoverage.cpp
@@ -69,7 +69,7 @@ Expected<std::unique_ptr<MemoryBuffer>> CodeCoverage::readProfile(StringRef Prof
     }
     
     // Create reader for file
-    auto FS = llvm::vfs::getRealFileSystem();
+    auto FS = llvm::vfs::createPhysicalFileSystem();
     auto ReaderOrErr = InstrProfReader::create(ProfrawPath, *FS);
     if (Error E = ReaderOrErr.takeError()) {
         return std::move(E);

--- a/Sources/CCodeCoverageParserLLVM19/CodeCoverage.cpp
+++ b/Sources/CCodeCoverageParserLLVM19/CodeCoverage.cpp
@@ -69,7 +69,7 @@ Expected<std::unique_ptr<MemoryBuffer>> CodeCoverage::readProfile(StringRef Prof
     }
     
     // Create reader for file
-    auto FS = llvm::vfs::getRealFileSystem();
+    auto FS = llvm::vfs::createPhysicalFileSystem();
     auto ReaderOrErr = InstrProfReader::create(ProfrawPath, *FS);
     if (Error E = ReaderOrErr.takeError()) {
         return std::move(E);

--- a/Tests/CodeCoverageTests/CodeCoverageTests.swift
+++ b/Tests/CodeCoverageTests/CodeCoverageTests.swift
@@ -7,7 +7,9 @@
 import XCTest
 @testable import CodeCoverage
 
-func test234() {}
+func test234() {
+    let _ = 1
+}
 
 func test123() {
     test234()
@@ -15,6 +17,11 @@ func test123() {
 
 func test456() {
     test123()
+}
+
+func test789() {
+    test123()
+    test456()
 }
 
 final class CodeCoverageTests: XCTestCase {
@@ -53,7 +60,7 @@ final class CodeCoverageTests: XCTestCase {
         let coverage = Self.coverage!
         
         try coverage.startCoverageGathering()
-        test456()
+        test789()
         let file = try coverage.stopCoverageGathering()
         defer { try? FileManager.default.removeItem(at: file) }
         
@@ -65,7 +72,7 @@ final class CodeCoverageTests: XCTestCase {
         let coverage = Self.coverage!
         self.measure {
             try! coverage.startCoverageGathering()
-            test123()
+            test789()
             let file = try! coverage.stopCoverageGathering()
             defer { try? FileManager.default.removeItem(at: file) }
             let _ = try! coverage.filesCovered(in: file)
@@ -73,20 +80,27 @@ final class CodeCoverageTests: XCTestCase {
     }
     
     func testMultithreadedParsing() throws {
-        let iterations = 100
+        let iterations = 1000
+        // Collector isn't thread safe and should be called from the main thread
         let files = try (0..<iterations).map { index in
             try Self.coverage.startCoverageGathering()
             if index % 2 == 0 {
-                test123()
+                test789()
             } else {
                 test456()
             }
             return try Self.coverage.stopCoverageGathering()
         }
-        DispatchQueue.concurrentPerform(iterations: iterations) { index in
-            let file = files[index]
-            defer { try? FileManager.default.removeItem(at: file) }
-            let _ = try! Self.coverage.filesCovered(in: file)
+        // Parser should work properly with multiple threads
+        let queue = OperationQueue()
+        queue.maxConcurrentOperationCount = ProcessInfo.processInfo.activeProcessorCount
+        queue.qualityOfService = .userInteractive
+        files.forEach { file in
+            queue.addOperation {
+                defer { try? FileManager.default.removeItem(at: file) }
+                let _ = try! Self.coverage.filesCovered(in: file)
+            }
         }
+        queue.waitUntilAllOperationsAreFinished()
     }
 }


### PR DESCRIPTION
### What and why?

Attempt to fix File System related crash on parsing.

### How?

Made a local object for FileSystem instead of the shared one. Seems as it's not thread-safe.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [] Make sure each commit and the PR mention the Issue number or JIRA reference
